### PR TITLE
Make controller template an abstract base class

### DIFF
--- a/Controllers/controller_do_mpc.py
+++ b/Controllers/controller_do_mpc.py
@@ -4,6 +4,7 @@ import do_mpc
 
 import numpy as np
 
+from Controllers.template_controller import template_controller
 from CartPole.cartpole_model import p_globals, s0, cartpole_ode, Q2u
 
 from copy import deepcopy
@@ -12,7 +13,7 @@ from copy import deepcopy
 dt_mpc_simulation = 0.2  # s
 mpc_horizon = 10
 
-class controller_do_mpc:
+class controller_do_mpc(template_controller):
     def __init__(self,
                  position_init=0.0,
                  positionD_init=0.0,

--- a/Controllers/controller_do_mpc_discrete.py
+++ b/Controllers/controller_do_mpc_discrete.py
@@ -4,6 +4,7 @@ import do_mpc
 from copy import deepcopy
 import numpy as np
 
+from Controllers.template_controller import template_controller
 from CartPole.cartpole_model import p_globals, s0, Q2u, cartpole_ode
 from types import SimpleNamespace
 
@@ -50,7 +51,7 @@ def cartpole_integration(s, dt):
     return s_next
 
 
-class controller_do_mpc_discrete:
+class controller_do_mpc_discrete(template_controller):
     def __init__(self,
                  position_init=0.0,
                  positionD_init=0.0,

--- a/Controllers/controller_lqr.py
+++ b/Controllers/controller_lqr.py
@@ -8,9 +8,10 @@ import numpy as np
 
 from copy import deepcopy
 
+from Controllers.template_controller import template_controller
 from CartPole.cartpole_model import cartpole_jacobian, p_globals, s0
 
-class controller_lqr:
+class controller_lqr(template_controller):
     def __init__(self):
         # From https://github.com/markwmuller/controlpy/blob/master/controlpy/synthesis.py#L8
         """Solve the continuous time LQR controller for a continuous time system.
@@ -30,7 +31,7 @@ class controller_lqr:
         """
         # ref Bertsekas, p.151
 
-        # Calculate Jacobian around equlibrium
+        # Calculate Jacobian around equilibrium
         # Set point around which the Jacobian should be linearized
         # It can be here either pole up (all zeros) or pole down
         s = s0

--- a/Controllers/controller_mpc_opti.py
+++ b/Controllers/controller_mpc_opti.py
@@ -1,5 +1,6 @@
 """mpc controller"""
 
+from Controllers.template_controller import template_controller
 from CartPole.cartpole_model import p_globals, s0, Q2u, cartpole_ode
 from types import SimpleNamespace
 
@@ -52,7 +53,7 @@ def cartpole_integration(s, dt):
     return s_next
 
 
-class controller_mpc_opti:
+class controller_mpc_opti(template_controller):
     def __init__(self):
 
         """

--- a/Controllers/template_controller.py
+++ b/Controllers/template_controller.py
@@ -2,16 +2,16 @@
 This is a linear-quadratic regulator
 It assumes that the input relation is u = Q*p.u_max (no fancy motor model) !
 """
-
+from abc import ABC, abstractmethod
 from CartPole.cartpole_model import cartpole_jacobian, cartpole_ode, p_globals, s0
 
 
-class template_controller:
+class template_controller(ABC):
 
     def __init__(self):
         pass
-
-
+    
+    @abstractmethod
     def step(self, s, target_position, time=None):
         Q = None  # This line is not obligatory. ;-) Just to indicate that Q must me defined and returned
         pass
@@ -21,7 +21,7 @@ class template_controller:
     # Optionally: A method called after an experiment.
     # May be used to print some statistics about controller performance (e.g. number of iter. to converge)
     def controller_report(self):
-        pass
+        raise NotImplementedError
 
     # Optionally: reset the controller after an experiment
     # May be useful for stateful controllers, like these containing RNN,
@@ -29,4 +29,4 @@ class template_controller:
     # It is called after an experiment,
     # but only if the controller is supposed to be reused without reloading (e.g. in GUI)
     def controller_reset(self):
-        pass
+        raise NotImplementedError


### PR DESCRIPTION
This is the restructuring I talked about. The controller template is now an abstract base class. Only small change, but formally nicer in my opinion. @marcinpaluch1994 I'm open to your feedback. Since there is no right or wrong in this thing, please tell me if you like the change.