### PR TITLE
Show controller report when running data generator

### DIFF
--- a/run_data_generator.py
+++ b/run_data_generator.py
@@ -98,6 +98,11 @@ for i in range(number_of_experiments):
         save_mode=save_mode
     )
 
+    try:
+        CartPoleInstance.controller.controller_report()
+    except:
+        pass
+
     gen_end = timeit.default_timer()
     gen_dt = (gen_end - gen_start) * 1000.0
     print('time to generate data: {} ms'.format(gen_dt))


### PR DESCRIPTION
It's nice to see the final plots but not having to run the GUI. That's why I added these lines to my own workflow. Does it make sense or should the data generator not open any windows? I would also understand why the latter would be a sensible design choice. In that case we could create an option to show plots or something. Happy to hear feedback.