### PR TITLE
Add a consistent action-space dimension to controllers

### DIFF
--- a/CartPole/cartpole_model_tf.py
+++ b/CartPole/cartpole_model_tf.py
@@ -6,6 +6,8 @@ from CartPole.state_utilities import (
 )
 import tensorflow as tf
 
+from SI_Toolkit.TF.TF_Functions.Compile import Compile
+
 from others.p_globals import (
     k, M, m, g, J_fric, M_fric, L, v_max, u_max, controlDisturbance, controlBias, TrackHalfLength
 )
@@ -172,11 +174,13 @@ def cartpole_integration(angle, angleD, angleDD, position, positionD, positionDD
 
     return angle_next, angleD_next, position_next, positionD_next
 
-# @tf.function(jit_compile=True)
+
+@Compile
 def euler_step_tf(state, stateD, t_step):
     return state + stateD * t_step
 
-# @tf.function(jit_compile=True)
+
+@Compile
 def cartpole_integration_tf(angle, angleD, angleDD, position, positionD, positionDD, t_step, ):
     angle_next = euler_step_tf(angle, angleD, t_step)
     angleD_next = euler_step_tf(angleD, angleDD, t_step)

--- a/CartPole/cartpole_tf.py
+++ b/CartPole/cartpole_tf.py
@@ -4,6 +4,8 @@ from CartPole.cartpole_model_tf import _cartpole_ode, euler_step_tf, edge_bounce
 from CartPole.state_utilities import ANGLE_IDX, ANGLE_SIN_IDX, ANGLE_COS_IDX, ANGLED_IDX, POSITION_IDX, POSITIOND_IDX, \
     STATE_INDICES
 
+from SI_Toolkit.TF.TF_Functions.Compile import Compile
+
 from others.p_globals import (
     k, M, m, g, J_fric, M_fric, L, v_max, u_max, controlDisturbance, controlBias, TrackHalfLength
 )
@@ -36,7 +38,7 @@ _cartpole_ode_tf = _cartpole_ode
 edge_bounce_tf = edge_bounce
 
 
-# @tf.function(jit_compile=True)
+@Compile
 def wrap_angle_rad(sin, cos):
     return tf.math.atan2(sin, cos)
 
@@ -48,7 +50,7 @@ cartpole_ode_tf = cartpole_ode
 edge_bounce_wrapper_tf = edge_bounce_wrapper
 
 
-# @tf.function(jit_compile=True)
+@Compile
 def edge_bounce_wrapper(angle, angle_cos, angleD, position, positionD, t_step, L=L):
     angle_bounced = tf.TensorArray(tf.float32, size=tf.size(angle), dynamic_size=False)
     angleD_bounced = tf.TensorArray(tf.float32, size=tf.size(angleD), dynamic_size=False)
@@ -72,7 +74,7 @@ def edge_bounce_wrapper(angle, angle_cos, angleD, position, positionD, t_step, L
     return angle_bounced_tensor, angleD_bounced_tensor, position_bounced_tensor, positionD_bounced_tensor
 
 
-# @tf.function(jit_compile=True)
+@Compile
 def Q2u_tf(Q):
     """
     Converts dimensionless motor power [-1,1] to a physical force acting on a cart.
@@ -101,6 +103,7 @@ def Q2u_tf(Q):
 #                               tf.TensorSpec(shape=[], dtype=tf.float32), tf.TensorSpec(shape=[], dtype=tf.float32),
 #                               tf.TensorSpec(shape=[], dtype=tf.float32), tf.TensorSpec(shape=[], dtype=tf.float32),
 #                               tf.TensorSpec(shape=[], dtype=tf.float32), tf.TensorSpec(shape=[], dtype=tf.float32)])
+@Compile
 def _cartpole_fine_integration_tf(angle, angleD,
                                   angle_cos, angle_sin,
                                   position, positionD,
@@ -132,7 +135,7 @@ def _cartpole_fine_integration_tf(angle, angleD,
     return angle, angleD, position, positionD, angle_cos, angle_sin
 
 
-# @tf.function(jit_compile=True)
+@Compile
 def cartpole_fine_integration_tf(s, u, t_step, intermediate_steps,
                                  k=k, M=M, m=m, g=g, J_fric=J_fric, M_fric=M_fric, L=L):
     #print('test 5')

--- a/config.yml
+++ b/config.yml
@@ -80,7 +80,7 @@ controller:
     R: 1.0                                # How much to punish Q
     # mc stands for mathematical correct, as this controller uses the formula from the paper
     LBD_mc: 10.0                          # Cost parameter lambda
-    SQRTRHOINV_mc: [0.002]                # Sampling variance
+    SQRTRHOINV_mc: 0.002                  # Sampling variance
     NU_mc: 20.0                           # Exploration variance
     GAMMA: 1.00                           # Future cost discount
     LR: 1000                             # Learning rate for adaption of variance, !!! Set to 0 to retrieve a mppi version in accordance with mppi paper
@@ -106,7 +106,7 @@ controller:
     R: 1.0                                # How much to punish Q
     LBD: 100.0                            # Cost parameter lambda
     NU: 1000.0                            # Exploration variance
-    SQRTRHOINV: [0.02]                    # Sampling variance
+    SQRTRHOINV: 0.02                      # Sampling variance
     GAMMA: 1.00                           # Future cost discount
     SAMPLING_TYPE: "interpolated"         # One of ["iid", "random_walk", "uniform", "repeated", "interpolated"]
     LOGGING: False                        # Collect and show detailed insights into the controller's behavior
@@ -188,6 +188,7 @@ cartpole:
     sigma_position: 0.0005
     sigma_angleD: 0.075 # This is much smaller than would result from sigma_angle under assumption of iir filter+derviative calculation; the theoretical value would be 2.28
     sigma_positionD: 0.005
+  num_control_inputs: 1
 
 
 data_generator:


### PR DESCRIPTION
- Before: Most controllers use (batch x horizon) tensors
- Now, it's (batch x horizon x action-size) everywhere, as predictors and cost functions also use this convention
- Use Compile decorator everywhere