### PR TITLE
Switching between up and down equilibrium

### DIFF
--- a/CartPole/__init__.py
+++ b/CartPole/__init__.py
@@ -101,7 +101,8 @@ class CartPole(EnvironmentBatched):
         self.u = 0.0  # Physical force acting on the cart
         self.Q = 0.0  # Dimensionless motor power in the range [-1,1] from which force is calculated with Q2u() method
         self._target_position = 0.0
-        self.target_equilibrium = 1.0  # Up is 1.0, Down is -1.0
+        self._target_equilibrium = 1.0  # Up is 1.0, Down is -1.0, here just a placeholder, change line below
+        self.target_equilibrium = 1.0
 
         self.action_space = MockSpace(-1.0, 1.0)
 
@@ -328,8 +329,16 @@ class CartPole(EnvironmentBatched):
         return self._target_position
 
     @property
+    def target_equilibrium(self):
+        return self._target_equilibrium
+
+    @property
     def target_position_tf(self):
         return self._target_position_tf
+
+    @property
+    def target_equilibrium_tf(self):
+        return self._target_equilibrium_tf
     
     @target_position.setter
     def target_position(self, target_position):
@@ -338,6 +347,14 @@ class CartPole(EnvironmentBatched):
             self._target_position_tf = tf.Variable(target_position, dtype=tf.float32)
         else:
             self._target_position_tf.assign(target_position)
+
+    @target_equilibrium.setter
+    def target_equilibrium(self, target_equilibrium):
+        self._target_equilibrium = target_equilibrium
+        if not hasattr(self, "_target_equilibrium_tf"):
+            self._target_equilibrium_tf = tf.Variable(target_equilibrium, dtype=tf.float32)
+        else:
+            self._target_equilibrium_tf.assign(target_equilibrium)
 
     def block_pole_at_90_deg(self):
         if self.stop_at_90:

--- a/GUI/_CartPoleGUI_MainWindow.py
+++ b/GUI/_CartPoleGUI_MainWindow.py
@@ -237,14 +237,58 @@ class MainWindow(QMainWindow):
         lspb.addWidget(self.bss)
         lspb.addWidget(self.bp)
 
+        lb = QVBoxLayout()  # Layout for buttons
+        lb.addLayout(lspb)
+        lb.addWidget(bq)
+
         # endregion
+
+        # region - up/down equilibrium switch
+        lud = QHBoxLayout()
+
+        # Left side - Tag
+        lud_left = QVBoxLayout()
+        lud_left.addStretch(1)
+        lud_left.addWidget(QLabel('Target\nequilibrium:'))
+        lud_left.addStretch(1)
+
+        # Right side - buttons
+        self.available_equilibria = ['Up', 'Down']
+        self.rbs_equilibrium = []
+        for equilibrium_name in self.available_equilibria:
+            self.rbs_equilibrium.append(QRadioButton(equilibrium_name))
+
+        # Ensures that radio buttons are exclusive
+        self.equilibria_buttons_group = QButtonGroup()
+        for button in self.rbs_equilibrium:
+            self.equilibria_buttons_group.addButton(button)
+
+        lud_right = QVBoxLayout()
+        lud_right.addStretch(1)
+
+        for rb in self.rbs_equilibrium:
+            rb.clicked.connect(self.RadioButtons_equilibrium)
+            lud_right.addWidget(rb)
+        lud_right.addStretch(1)
+
+        if self.CartPoleInstance.target_equilibrium == 1.0:
+            initial_target_equilibrium = 'Up'
+        else:
+            initial_target_equilibrium = 'Down'
+
+        self.rbs_equilibrium[self.available_equilibria.index(initial_target_equilibrium)].setChecked(True)
+
+        lud.addLayout(lud_left)
+        lud.addLayout(lud_right)
+
+        l_main_buttons_and_equilibria = QHBoxLayout()
+        l_main_buttons_and_equilibria.addLayout(lb, stretch=1)
+        l_main_buttons_and_equilibria.addLayout(lud)
+        layout.addLayout(l_main_buttons_and_equilibria)
 
         # region - Sliders setting initial state and buttons for kicking the pole
 
         # Sliders setting initial position and angle
-        lb = QVBoxLayout()  # Layout for buttons
-        lb.addLayout(lspb)
-        lb.addWidget(bq)
         ip = QHBoxLayout()  # Layout for initial position sliders
         self.initial_position_slider = QSlider(orientation=Qt.Orientation.Horizontal)
         self.initial_position_slider.setRange(-int(float(1000*TrackHalfLength)), int(float(1000*TrackHalfLength)))
@@ -310,8 +354,7 @@ class MainWindow(QMainWindow):
         ip.addWidget(kick_left_button)
         ip.addWidget(kick_right_button)
 
-        lb.addLayout(ip)
-        layout.addLayout(lb)
+        layout.addLayout(ip)
 
         # endregion
 
@@ -914,6 +957,14 @@ class MainWindow(QMainWindow):
         self.reset_variables(0)
         self.CartPoleInstance.draw_constant_elements(self.fig, self.fig.AxCart, self.fig.AxSlider)
         self.canvas.draw()
+
+    # Chose the equilibrium - stabilize up or down
+    def RadioButtons_equilibrium(self):
+        sleep(0.001)
+        if self.rbs_equilibrium[0].isChecked():
+            self.CartPoleInstance.target_equilibrium = 1.0
+        else:
+            self.CartPoleInstance.target_equilibrium = -1.0
 
     # Chose the noise mode - effect of start/stop button
     def RadioButtons_noise_on_off(self):

--- a/others/cost_functions/CartPole/cost_function.py
+++ b/others/cost_functions/CartPole/cost_function.py
@@ -8,8 +8,10 @@ class cartpole_cost_function:
         self.env_mock = environment
         if self.env_mock.lib == TensorFlowLibrary:
             self.target_position_attribute = "target_position_tf"
+            self.target_equilibrium_attribute = "target_equilibrium_tf"
         elif self.env_mock.lib == NumpyLibrary:
             self.target_position_attribute = "target_position"
+            self.target_equilibrium_attribute = "target_equilibrium"
         else:
             raise ValueError(
                 "Currently, this cost function only supports environment written in TensorFlow or NumPy (not PyTorch etc.)"
@@ -18,3 +20,7 @@ class cartpole_cost_function:
     @property
     def target_position(self) -> Union[float, tf.Variable]:
         return getattr(self.env_mock, self.target_position_attribute)
+
+    @property
+    def target_equilibrium(self) -> Union[float, tf.Variable]:
+        return getattr(self.env_mock, self.target_equilibrium_attribute)

--- a/others/cost_functions/CartPole/default.py
+++ b/others/cost_functions/CartPole/default.py
@@ -33,7 +33,7 @@ class default(cartpole_cost_function):
     # cost for difference from upright position
     def E_pot_cost(self, angle):
         """Compute penalty for not balancing pole upright (penalize large angles)"""
-        return 0.25 * (1.0 - tf.cos(angle)) ** 2
+        return self.target_equilibrium * 0.25 * (1.0 - tf.cos(angle)) ** 2
 
     # actuation cost
     def CC_cost(self, u):

--- a/others/cost_functions/CartPole/quadratic_boundary.py
+++ b/others/cost_functions/CartPole/quadratic_boundary.py
@@ -37,7 +37,7 @@ class quadratic_boundary(cartpole_cost_function):
     # cost for difference from upright position
     def E_pot_cost(self, angle):
         """Compute penalty for not balancing pole upright (penalize large angles)"""
-        return 0.25 * (1.0 - tf.cos(angle)) ** 2
+        return self.target_equilibrium * 0.25 * (1.0 - tf.cos(angle)) ** 2
 
     # actuation cost
     def CC_cost(self, u):

--- a/others/cost_functions/CartPole/quadratic_boundary_grad.py
+++ b/others/cost_functions/CartPole/quadratic_boundary_grad.py
@@ -39,7 +39,7 @@ class quadratic_boundary_grad(cartpole_cost_function):
     # cost for difference from upright position
     def E_pot_cost(self, angle):
         """Compute penalty for not balancing pole upright (penalize large angles)"""
-        return 0.25 * (1.0 - tf.cos(angle)) ** 2
+        return self.target_equilibrium * 0.25 * (1.0 - tf.cos(angle)) ** 2
     
     def E_kin_cost(self, angleD):
         """Compute penalty for not balancing pole upright (penalize large angles)"""

--- a/others/cost_functions/CartPole/quadratic_boundary_nonconvex.py
+++ b/others/cost_functions/CartPole/quadratic_boundary_nonconvex.py
@@ -50,7 +50,7 @@ class quadratic_boundary_nonconvex(cartpole_cost_function):
     # cost for difference from upright position
     def E_pot_cost(self, angle):
         """Compute penalty for not balancing pole upright (penalize large angles)"""
-        return 0.25 * (1.0 - tf.cos(angle)) ** 2
+        return self.target_equilibrium * 0.25 * (1.0 - tf.cos(angle)) ** 2
 
     # actuation cost
     def CC_cost(self, u):


### PR DESCRIPTION
Adding functionality to CartPole Env to chose target between up or down equilibrium. The default is set as up. Added button to CartPole GUI. No options added to config or data generator. For data generation in Sim one can just restart experiment with pole down, so probably no need for adding it there. The feature was added to speed up bringing pole down for data generation on physical cartpole)